### PR TITLE
A limit has been set to restrict local storage to a maximum of 10 objects.

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -150,6 +150,15 @@ const saveSearchHistory = (cityName, lat, lon) => {
         lon: lon,
     };
 
+    // To limit the array of objects to a maximum of 10 items, an if-statement has been added to remove the last items until there are only 9 remaining. 
+    // The new city is added to the beginning of the array using the unshift() method below, becoming the 10th and most recent item.
+    if (searchHistory.length >= 10) {
+        while (searchHistory.length > 9) {
+            searchHistory.pop();
+            console.log(searchHistory.length)
+        }   
+    }
+
     // an if-statement that verifies whether the current search city already exists in the localStorage and prevents it from being duplicated.
     if (searchHistory.length > 0) {
         for (let i = 0; i < searchHistory.length; i++) {
@@ -159,11 +168,11 @@ const saveSearchHistory = (cityName, lat, lon) => {
         }
     };
 
-    searchHistory.push(newSearchItem);
-
+    searchHistory.unshift(newSearchItem);
     localStorage.setItem('searchHistory', JSON.stringify(searchHistory));
 
     createCityButton(newSearchItem.cityName);
+    document.getElementById('search-input').value = ''; // erases the input field's contents.
 }
 
 // Display gif based on AQI value


### PR DESCRIPTION
To restrict local storage from holding more than 10 objects, a validation has been implemented. When the user searches for a new city, the `saveSearchHistory()` function is called to validate and save the new city data to the local storage. If there are already 10 objects in local storage, the `if` statement will use a `while` loop to remove the last object using `pop()` until there are no more than 9 objects. The new city and its corresponding data will be added to the array of objects under the 0 index using `unshift()` (instead of `push())` so that the newest city history item appears as the first one under the input field when page is loaded, rather than the last.

Additionally, when a new city search is added as a history button under the input field, the input field value will be cleared so that the user can easily type a new city name if needed, rather than having to delete the previous search first.