### PR TITLE
Update city name in local storage

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -111,7 +111,7 @@ searchBtn.addEventListener('click', function(event) {
                 const lon = data[0].lon;
     
                 getPollution(lat, lon);
-                saveSearchHistory(searchInputVal, lat, lon);
+                saveSearchHistory(data[0].name, lat, lon);
             }
         });
     }    


### PR DESCRIPTION
Save returned value for city name in local storage instead of typed input so that buttons have capitalized city names even when user doesn't capitalize their search input